### PR TITLE
Fix to handle LDAP users.

### DIFF
--- a/repo-login-switcher/src/main/java/com/switcher/login/webscript/SwitchUserWebScript.java
+++ b/repo-login-switcher/src/main/java/com/switcher/login/webscript/SwitchUserWebScript.java
@@ -25,6 +25,8 @@ import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 import org.springframework.extensions.webscripts.*;
 
+import com.switcher.login.security.authentication.SwitchUserAuthenticationServiceImpl;
+
 import javax.servlet.http.HttpServletResponse;
 import java.util.HashMap;
 import java.util.Map;
@@ -66,7 +68,7 @@ public class SwitchUserWebScript extends DeclarativeWebScript {
 
         try {
             // save current user for future use by @see com.switcher.login.security.authentication.SwitchUserAuthenticationServiceImpl.authenticate
-            AlfrescoTransactionSupport.bindResource("currentUser", AuthenticationUtil.getRunAsUser());
+            AlfrescoTransactionSupport.bindResource(SwitchUserAuthenticationServiceImpl.CURRENT_USER_KEY, AuthenticationUtil.getRunAsUser());
             // get ticket
             authenticationService.authenticate(username, password.toCharArray());
 

--- a/repo-login-switcher/src/main/resources/alfresco/subsystems/Authentication/alfrescoNtlmSwitch/switch-user-authentication-context.xml
+++ b/repo-login-switcher/src/main/resources/alfresco/subsystems/Authentication/alfrescoNtlmSwitch/switch-user-authentication-context.xml
@@ -22,7 +22,6 @@
 
     <bean id="localAuthenticationService"
           class="com.switcher.login.security.authentication.SwitchUserAuthenticationServiceImpl">
-        <property name="authenticationComponent" ref="authenticationComponent"/>
         <property name="authorityService" ref="AuthorityService"/>
     </bean>
 


### PR DESCRIPTION
Your plugin work great with local users (managed by alfrescoNtlm) but not with users synchronized with LDAP.  When calling authenticationComponent.setCurrentUser(), the component look for the user in user storeroot, because the alfrescoNtlm authenticationComponent only manage local user like 'admin'. In order to find users from LDAP, we have to use the global authenticationComponent, not the one in a particular subsystem.

The global authenticationComponent will ask each subsystem if it know the user.  In order to have the global authenticationComponent, we use   applicationContext.getParent().getBean("authenticationComponent")

I also use a constant instead of "currentuser" to clarify.